### PR TITLE
Fix(packer) : nvim-treesitter plugins `use` conditions

### DIFF
--- a/plugin/plugins.lua
+++ b/plugin/plugins.lua
@@ -66,12 +66,16 @@ require('packer').startup(function()
 
     use {
         'nvim-treesitter/playground',
-        after = "nvim-treesitter"
+        requires = {
+            'nvim-telescope/telescope.nvim',
+        }
     }
 
     use {
         'nvim-treesitter/nvim-treesitter-textobjects',
-        after = "nvim-treesitter"
+        requires = {
+            'nvim-telescope/telescope.nvim',
+        }
     }
 
 


### PR DESCRIPTION
    Remove `after` and add `requires` conditions for :

        - nvim-treesitter/playground
        - nvim-treesitter/nvim-treesitter-textobjects