### PR TITLE
Settings(gitsigns) : Update mappings (see gitsigns 66638c9)

### DIFF
--- a/plugin/gitsigns.lua
+++ b/plugin/gitsigns.lua
@@ -12,7 +12,6 @@ require('gitsigns').setup {
     linehl = false,
     keymaps = {
         noremap = true,
-        buffer = true,
 
         -- netx/prev_hunk
         ['n <leader>hn'] = { expr = true, "&diff ? ']c' : '<cmd>lua require\"gitsigns\".next_hunk()<CR>'"},


### PR DESCRIPTION
    Remove buffer-scope mappings, as gitsigns new defaults
    since commit [66638c9](https://github.com/lewis6991/gitsigns.nvim/commit/66638c929c61f950246f3d292b6157a9596241de)