### PR TITLE
Fix(nohlsearch) : Use nohlsearch default mapping

### DIFF
--- a/lua/modules/core/mappings.lua
+++ b/lua/modules/core/mappings.lua
@@ -11,15 +11,10 @@ u.map('n', '<leader>R', '<cmd>source $MYVIMRC<cr>')
 u.map('n', '<leader>i', 'mmgg=G`m<cr>')
 
 -- easier windows jump
-u.map('n', '<C-h>', '<C-w>h')
 u.map('n', '<C-Left>', '<C-w>h')
-u.map('n', '<C-l>', '<C-w>l')
 u.map('n', '<C-Right>', '<C-w>l')
-u.map('n', '<C-j>', '<C-w>j')
 u.map('n', '<C-Down>', '<C-w>j')
-u.map('n', '<C-k>', '<C-w>k')
 u.map('n', '<C-Up>', '<C-w>k')
-u.map('n', '<leader><space>', '<cmd>nohlsearch<cr>')
 
 --- Resize windows
 u.map('n', '<leader>+', '<cmd>vertical resize +10<cr>')


### PR DESCRIPTION
As  `:nohlsearch` can be triggered with <C-l> default mapping, it's better to keep the default one. 
As I already add <C-l> mapping for window jumping (as `<C-h>` `<C-j>` `<C-k>`), I prefer removing these mappings that I actually don't use.