### PR TITLE
Refactor(autocommands): Use new vim.api.nvim_create_autocmd

### DIFF
--- a/lua/modules/core/autocommands.lua
+++ b/lua/modules/core/autocommands.lua
@@ -1,37 +1,47 @@
 -- autocommands
-local exec = vim.api.nvim_exec
+vim.api.nvim_create_autocmd('BufEnter', {
+    desc = 'Do not auto comment on new line',
+    command = 'set fo-=c fo-=r fo-=o',
+})
 
-local TrimWhitespace = exec(
-    [[
-    function! TrimWhitespace()
-        let l:save = winsaveview()
-        keeppatterns %s/\s\+$//e
-        call winrestview(l:save)
-    endfunction
-
-    call TrimWhitespace()
-    ]],
-    true
-)
-
--- don't auto commenting new lines
-exec([[au BufEnter * set fo-=c fo-=r fo-=o]], false)
-
--- disable IndentLine for markdown files (avoid concealing)
-exec([[au FileType markdown let g:indentLine_enabled=0]], false)
+vim.api.nvim_create_autocmd({ 'FileType markdown' }, {
+    desc = 'Disable IndentLine for markdown files',
+    command = 'let g:indentLine_enabled=0',
+})
 
 -- keep windows equally resized
-exec([[au VimResized * tabdo wincmd =]], false)
+vim.api.nvim_create_autocmd('VimResized', {
+    desc = 'Keep windows equally resized',
+    command = 'tabdo wincmd =',
+})
 
--- filetype
-exec([[au BufRead,BufNewFile *.sol set filetype=solidity]], false)
-exec([[au BufRead,BufNewFile *.twig set filetype=html.twig]], false)
+vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead' }, {
+    desc = 'Fix solidity filetype',
+    pattern = '*.sol',
+    command = 'set filetype=solidity',
+})
 
--- git commit
-exec([[au BufNewFile,BufRead COMMIT_EDITMSG set spell nonumber wrap linebreak]], false)
-exec([[au filetype gitcommit let b:EditorConfig_disable=1]], false)
+vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead' }, {
+    desc = 'Fix twig filetype',
+    pattern = '*.twig',
+    command = 'set filetype=html.twig',
+})
 
--- trim_white_space
-exec([[au BufWritePre * call TrimWhitespace()]], false)
+vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead' }, {
+    desc = 'Git commit messages settings',
+    pattern = 'COMMIT_EDITMSG',
+    command = 'set spell nonumber wrap linebreak',
+})
 
-exec([[au CursorHold * lua vim.diagnostic.open_float(nil,{focusable=false,scope="cursor"})]], false)
+vim.api.nvim_create_autocmd({ 'FileType' }, {
+    desc = 'Git messages settings',
+    pattern = 'gitcommit',
+    command = 'let b:EditorConfig_disable=1',
+})
+
+vim.api.nvim_create_autocmd('CursorHold', {
+    desc = 'Show current line diagnostics',
+    callback = function()
+        vim.diagnostic.open_float(nil, { focusable = false, scope = 'cursor' })
+    end,
+})


### PR DESCRIPTION
Now that neovim/neovim/pull/17551 is merged, we have a new
api for autocommands. In this commit, we try to replace the
old autocommands with this new api :)