### PR TITLE
Settings(nvim-tree) : Remove useless "refresh" mapping

### DIFF
--- a/lua/modules/plugins/nvimtree.lua
+++ b/lua/modules/plugins/nvimtree.lua
@@ -25,4 +25,3 @@ require('nvim-tree').setup(config)
 -- mappings
 local u = require('utils')
 u.map('n', '<leader>e', ':NvimTreeToggle<CR>')
-u.map('n', '<leader>r', ':NvimTreeRefresh<CR>')


### PR DESCRIPTION
refresh is already available out of the box with `R`