### PR TITLE
Refactor : Rename nvim_add_user_command to nvim_create_user_command

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -87,7 +87,7 @@ M.timer = {
 }
 
 M.command = function(name, fn, opts)
-    api.nvim_add_user_command(name, fn, opts or {})
+    api.nvim_create_user_command(name, fn, opts or {})
 end
 
 M.augroup = function(name, event, fn, ft)


### PR DESCRIPTION
Some API functions of as been renamed :

    nvim_add_user_command     -> nvim_create_user_command
    nvim_buf_add_user_command -> nvim_buf_create_user_command

This commit update to the last name when needed