### PR TITLE
Refac(trim whitespaces) : Replace null-ls builtin by our own fn

### DIFF
--- a/lua/modules/core/autocommands.lua
+++ b/lua/modules/core/autocommands.lua
@@ -76,3 +76,9 @@ autocmd({ 'BufReadPost' }, {
     end,
     group = vim.api.nvim_create_augroup('LastPosition', { clear = true }),
 })
+
+autocmd({ 'BufWritePre' }, {
+    desc = 'trim buffer whitespaces',
+    pattern = '*',
+    command = 'TrimTrailingWhitespace',
+})

--- a/lua/modules/lsp/null-ls.lua
+++ b/lua/modules/lsp/null-ls.lua
@@ -24,7 +24,6 @@ local sources = {
         disabled_filetypes = { 'typescript', 'typescriptreact' },
     }),
     with_root_file(b.formatting.stylua, 'stylua.toml'),
-    b.formatting.trim_whitespace,
     b.formatting.phpcsfixer.with({
         filetypes = { 'php' },
         command = 'php-cs-fixer',

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -2,12 +2,63 @@ local format = string.format
 local uv = vim.loop
 local api = vim.api
 
+-- global inspect fn
+_G.inspect = function(...)
+    print(vim.inspect(...))
+end
+
 local get_map_options = function(custom_options)
     local options = { noremap = true, silent = true }
     if custom_options then
         options = vim.tbl_extend('force', options, custom_options)
     end
     return options
+end
+
+-- (see :h command-preview or https://github.com/neovim/neovim/commit/7380ebfc17723662f6fe1e38372f54b3d67fe082)
+local function trim_space(opts, preview_ns, preview_buf)
+    local line1 = opts.line1
+    local line2 = opts.line2
+    local buf = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, line1 - 1, line2, 0)
+    local new_lines = {}
+    local preview_buf_line = 0
+    for i, line in ipairs(lines) do
+        local startidx, endidx = string.find(line, '%s+$')
+        if startidx ~= nil then
+            -- Highlight the match if in command preview mode
+            if preview_ns ~= nil then
+                api.nvim_buf_add_highlight(buf, preview_ns, 'Substitute', line1 + i - 2, startidx - 1, endidx)
+                -- Add lines and highlight to the preview buffer
+                -- if inccommand=split
+                if preview_buf ~= nil then
+                    local prefix = string.format('|%d| ', line1 + i - 1)
+                    api.nvim_buf_set_lines(preview_buf, preview_buf_line, preview_buf_line, 0, { prefix .. line })
+                    api.nvim_buf_add_highlight(
+                        preview_buf,
+                        preview_ns,
+                        'Substitute',
+                        preview_buf_line,
+                        #prefix + startidx - 1,
+                        #prefix + endidx
+                    )
+                    preview_buf_line = preview_buf_line + 1
+                end
+            end
+        end
+        if not preview_ns then
+            new_lines[#new_lines + 1] = string.gsub(line, '%s+$', '')
+        end
+    end
+    -- Don't make any changes to the buffer if previewing
+    if not preview_ns then
+        api.nvim_buf_set_lines(buf, line1 - 1, line2, 0, new_lines)
+    end
+    -- When called as a preview callback, return the value of the
+    -- preview type
+    if preview_ns ~= nil then
+        return 2
+    end
 end
 
 local M = {}
@@ -49,10 +100,6 @@ M.table = {
         return false
     end,
 }
-
-_G.inspect = function(...)
-    print(vim.inspect(...))
-end
 
 M.timer = {
     start_time = nil,
@@ -127,5 +174,11 @@ end
 M.get_cwd = function()
     return uv.cwd
 end
+
+M.trim_trailing_whitespace = M.command(
+    'TrimTrailingWhitespace',
+    trim_space,
+    { nargs = '?', range = '%', addr = 'lines', preview = trim_space }
+)
 
 return M


### PR DESCRIPTION
* add trim_space utils function (the one shown in :h command-preview)
* add TrimTrailingWhitespace command
* add appropriate autocommand
* remove null-ls b.formatting.trim_whitespace