### PR TITLE
Settings(material) : Fix Normal bg color

### DIFF
--- a/lua/modules/core/colorscheme.lua
+++ b/lua/modules/core/colorscheme.lua
@@ -26,6 +26,9 @@ require('material').setup({
     disable = {
         background = true,
     },
+    custom_highlights = {
+        NormalNC = { bg = 'NONE' },
+    },
 })
 
 vim.cmd([[colorscheme material]])


### PR DESCRIPTION
Background color for unfocused windows has been modified since a bunch of material commits. 
This commit fix this.