### PR TITLE
refactor: autocommands

### DIFF
--- a/lua/custom/autocommands.lua
+++ b/lua/custom/autocommands.lua
@@ -82,12 +82,10 @@ vim.api.nvim_create_autocmd({ 'LspAttach' }, {
         local capabilities = client.server_capabilities
 
         -- diagnostics
-        vim.keymap.set('n', '[d', vim.diagnostic.goto_prev)
-        vim.keymap.set('n', ']d', vim.diagnostic.goto_next)
         vim.keymap.set('n', '<leader>D', vim.diagnostic.open_float)
 
         --- quickfix
-        vim.keymap.set('n', '<leader>q', vim.diagnostic.setqflist)
+        vim.keymap.set('n', '<leader>q', '<cmd>Trouble qflist<cr>', { buffer = args.buf })
 
         -- show definition of current symbol
         if capabilities.definitionProvider then
@@ -215,5 +213,13 @@ vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter', 'WinNew', 'VimResized' }, 
     pattern = { '*', '*.*' },
     command = 'let &scrolloff=(winheight(win_getid())/2) + 1',
 })
+vim.api.nvim_create_autocmd('BufEnter', {
+    callback = function(ctx)
+        local root = vim.fs.root(ctx.buf, { '.git', 'Makefile' })
+        if root then
+            vim.uv.chdir(root)
+        end
+    end,
+})
 
-vim.opt.updatetime = 400
+vim.opt.updatetime = 100


### PR DESCRIPTION
* remove redundant (default) move to prev/next diagnostics

* use Trouble instead of vim diagnostics for qflist autocommand

* reduce updatetime

* add cwd autocommand thanks to vim.fs.root