### PR TITLE
fix(autocommand): remove autochdir with vim.fs.root

### DIFF
--- a/lua/custom/autocommands.lua
+++ b/lua/custom/autocommands.lua
@@ -216,13 +216,5 @@ vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter', 'WinNew', 'VimResized' }, 
     pattern = { '*', '*.*' },
     command = 'let &scrolloff=(winheight(win_getid())/2) + 1',
 })
--- vim.api.nvim_create_autocmd('BufEnter', {
---     callback = function(ctx)
---         local root = vim.fs.root(ctx.buf, { '.git', 'Makefile' })
---         if root then
---             vim.uv.chdir(root)
---         end
---     end,
--- })
 
 vim.opt.updatetime = 100


### PR DESCRIPTION
this is not possible to use this with git submodules. It always spam errors saying files does not exist