### PR TITLE
fix(yazi): remove recommended init function

### DIFF
--- a/lua/plugins/yazi.lua
+++ b/lua/plugins/yazi.lua
@@ -4,6 +4,7 @@ return {
     dependencies = {
         { 'nvim-lua/plenary.nvim', lazy = true },
     },
+    event = 'VeryLazy',
     cmd = {
         'Yazi',
     },
@@ -33,10 +34,4 @@ return {
             open_and_pick_window = '<c-o>',
         },
     },
-    -- 👇 if you use `open_for_directories=true`, this is recommended
-    init = function()
-        -- mark netrw as loaded so it's not loaded at all.
-        -- More details: https://github.com/mikavilpas/yazi.nvim/issues/802
-        vim.g.loaded_netrwPlugin = 1
-    end,
 }


### PR DESCRIPTION
As netrw is already disable in init.lua, adding what's documentation explain about yazi required init function is useless, at least, and seems to have the opposite result (as `-` still open new dir plugin instead of yazi).