### PR TITLE
fix(neogit): statuscolumn

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -75,8 +75,8 @@ vim.opt.commentstring = ''
 
 vim.opt.fillchars:append({
     fold = ' ',
-    foldopen = '',
-    foldclose = '',
+    foldopen = '',
+    foldclose = '',
     foldsep = ' ',
 })
 

--- a/lua/plugins/neogit.lua
+++ b/lua/plugins/neogit.lua
@@ -26,5 +26,11 @@ return {
                 folded = false,
             },
         },
+        signs = {
+            -- { CLOSED, OPENED }
+            hunk = { '', '' },
+            item = { '', '' },
+            section = { '', '' },
+        },
     },
 }


### PR DESCRIPTION
Problem: Snacks is in charge of statuscolumn and neogit also shows it's
own signs. As result, two fold signs are displayed.

Solution: Unset Neogit signs and let statuscolumn/snacks do it.
We updated foldopen/foldclose signs to bigger ones
